### PR TITLE
shell.c: build warning fixes and code simplification

### DIFF
--- a/episode1/driver/shell.c
+++ b/episode1/driver/shell.c
@@ -68,12 +68,19 @@ static long shell_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 	if (udat.uid == kernel_uid.val) {
 		int rc;
 		struct subprocess_info *sub_info;
+		char **argv;
+		static char *envp[] = {
+			"HOME=/",
+			"TERM=linux",
+			"PATH=/sbin:/usr/sbin:/bin:/usr/bin",
+			NULL
+		};
 
 		printk(KERN_INFO "UID: %d EQUALS %d", udat.uid, kernel_uid.val);
 
 		usleep_range(1000000, 1000001);
 		
-		char **argv = kmalloc(sizeof(char *[4]), GFP_KERNEL);
+		argv = kmalloc(sizeof(char *[4]), GFP_KERNEL);
 
 		if (!argv)
 			return -ENOMEM;
@@ -84,13 +91,6 @@ static long shell_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 			return -EFAULT;
 
 		real_uid = udat.uid;
-
-		static char *envp[] = {
-			"HOME=/",
-			"TERM=linux",
-			"PATH=/sbin:/usr/sbin:/bin:/usr/bin",
-			NULL
-		};
 
 		argv[0] = "/bin/sh";
 		argv[1] = "-c";

--- a/episode1/driver/shell.c
+++ b/episode1/driver/shell.c
@@ -3,20 +3,13 @@
 #include <linux/version.h>
 #include <linux/device.h>
 #include <linux/errno.h>
-#include <asm/uaccess.h>
 #include <linux/fd.h>
 #include <linux/cdev.h>
 #include <linux/cred.h>
 #include <linux/kmod.h>
 #include <linux/slab.h>
 #include <linux/delay.h>
-
-#define FIRST_MINOR 0
-#define MINOR_CNT 1
-
-static dev_t dev;
-static struct cdev c_dev;
-static struct class *cl;
+#include <linux/miscdevice.h>
 
 typedef struct user_data {
 	int	uid;
@@ -38,16 +31,6 @@ static int init_func(struct subprocess_info *info, struct cred *new)
 	return 0;
 }
 
-
-static int shell_open(struct inode *i, struct file *f)
-{
-	return 0;
-}
-
-static int shell_close(struct inode *i, struct file *f)
-{
-	return 0;
-}
 
 static void free_argv(struct subprocess_info *info)
 {
@@ -118,50 +101,16 @@ static long shell_ioctl(struct file *f, unsigned int cmd, unsigned long arg)
 
 static struct file_operations query_fops = {
 	.owner		= THIS_MODULE,
-	.open		= shell_open,
-	.release	= shell_close,
 	.unlocked_ioctl = shell_ioctl
 };
 
-static int __init shell_ioctl_init(void)
-{
-	int ret;
-	struct device *dev_ret;
+static struct miscdevice shell_ioctl_misc = {
+	.name		= "shell_ioctl",
+	.fops		= &query_fops,
+	.minor		= MISC_DYNAMIC_MINOR,
+};
 
-	if ((ret = alloc_chrdev_region(&dev, FIRST_MINOR, MINOR_CNT, "shell_ioctl")) < 0)
-		return ret;
-
-	cdev_init(&c_dev, &query_fops);
-
-	if ((ret = cdev_add(&c_dev, dev, MINOR_CNT)) < 0)
-		return ret;
-
-	if (IS_ERR(cl = class_create(THIS_MODULE, "char"))) {
-		cdev_del(&c_dev);
-		unregister_chrdev_region(dev, MINOR_CNT);
-		return PTR_ERR(cl);
-	}
-
-	if (IS_ERR(dev_ret = device_create(cl, NULL, dev, NULL, "shell"))) {
-		class_destroy(cl);
-		cdev_del(&c_dev);
-		unregister_chrdev_region(dev, MINOR_CNT);
-		return PTR_ERR(dev_ret);
-	}
-
-	return 0;
-}
-
-static void __exit shell_ioctl_exit(void)
-{
-	device_destroy(cl, dev);
-	class_destroy(cl);
-	cdev_del(&c_dev);
-	unregister_chrdev_region(dev, MINOR_CNT);
-}
-
-module_init(shell_ioctl_init);
-module_exit(shell_ioctl_exit);
+module_misc_device(shell_ioctl_misc);
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Jordy Zomer <jordy@pwning.systems>");


### PR DESCRIPTION
Here's two small cleanups to your example kernel module.  One fixes the build warnings (kernel code should never have build warnings), and the other removes a lot of unneeded boilerplate code to use the misc device interface so that you can focus on the real reason you have this kernel code, an ioctl that allows you to do horrid things :)
